### PR TITLE
Fixed addSigner for paymentCred-only addresses

### DIFF
--- a/src/lucid/tx.ts
+++ b/src/lucid/tx.ts
@@ -270,7 +270,7 @@ export class Tx {
   addSigner(address: Address | RewardAddress) {
     const addressDetails = getAddressDetails(address);
 
-    if (!addressDetails.paymentCredential || !addressDetails.stakeCredential)
+    if (!addressDetails.paymentCredential && !addressDetails.stakeCredential)
       throw new Error('Not a valid address.');
 
     const credential =


### PR DESCRIPTION
In a recent project I needed to manually add the required signer via the txBuilder as opposed to being able to use the addSigner functionality from Lucid.

This change should address that issue such that when using an address without a reward credential, addSigner will still behave appropriately.