### PR TITLE
Tweaks for stake delegation + stake validators

### DIFF
--- a/src/lucid/tx.ts
+++ b/src/lucid/tx.ts
@@ -168,7 +168,7 @@ export class Tx {
             )
           )
         : C.StakeCredential.from_scripthash(
-            C.Ed25519KeyHash.from_bytes(
+            C.ScriptHash.from_bytes(
               fromHex(addressDetails.stakeCredential.hash)
             )
           );
@@ -200,7 +200,7 @@ export class Tx {
             )
           )
         : C.StakeCredential.from_scripthash(
-            C.Ed25519KeyHash.from_bytes(
+            C.ScriptHash.from_bytes(
               fromHex(addressDetails.stakeCredential.hash)
             )
           );
@@ -226,7 +226,7 @@ export class Tx {
             )
           )
         : C.StakeCredential.from_scripthash(
-            C.Ed25519KeyHash.from_bytes(
+            C.ScriptHash.from_bytes(
               fromHex(addressDetails.stakeCredential.hash)
             )
           );

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -290,7 +290,7 @@ export const getAddressDetails = (address: string): AddressDetails => {
         type: 'Reward',
         address: parsedAddress.to_address().to_bech32(),
       },
-      paymentCredential,
+      stakeCredential: paymentCredential,
     };
   } catch (e) {}
 
@@ -323,7 +323,7 @@ export const getAddressDetails = (address: string): AddressDetails => {
         type: 'Reward',
         address: parsedAddress.to_address().to_bech32(),
       },
-      paymentCredential,
+      stakeCredential: paymentCredential,
     };
   } catch (e) {}
   throw new Error('No address type matched for: ' + address);


### PR DESCRIPTION
Some minor changes I found to be necessary to allow stake delegation and stake validators. I'm not clear on the why the stake credential would be in the `payment_cred` field on reward addresses, so this may not be correct, but it seems to be what's expected by the calling functions.