### PR TITLE
Fix and update `PlutusData` type

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -183,7 +183,7 @@ export type PlutusData =
   | string
   | bigint
   | PlutusData[]
-  | Record<string, PlutusData>
+  | Map<PlutusData, PlutusData>
   | Construct; // We emulate the constr like this
 
 /** JSON object */

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -177,8 +177,6 @@ export type WalletProvider = 'nami' | 'eternl' | 'flint';
  *
  * Note: We need to wrap it in an object to prevent circular references
  */
-// TODO: Fix circular reference
-// @ts-ignore
 export type PlutusData =
   | string
   | bigint


### PR DESCRIPTION
The `Record<string, PlutusData>` variant should be a `Map<PlutusData, PlutusData>` according to the [`serialize` function](https://github.com/Berry-Pool/lucid/blob/c0828c0715fb1354b482e3baabf5c8f7d8c7a367/src/utils/data.ts#L17).

I also went ahead and fixed the circular referencing issue. I realize it's a breaking change, but it had to be done sometime. As it currently stands, `PlutusData` is just `any`.