### PR TITLE
Add a few utility functions

### DIFF
--- a/src/lucid/tx.ts
+++ b/src/lucid/tx.ts
@@ -10,10 +10,12 @@ import {
   Lovelace,
   MintingPolicy,
   NFTMetadata,
+  PaymentKeyHash,
   PoolId,
   Redeemer,
   RewardAddress,
   SpendingValidator,
+  StakeKeyHash,
   UnixTime,
   UTxO,
   WithdrawalValidator,
@@ -274,8 +276,15 @@ export class Tx {
     if (credential.type === 'Script')
       throw new Error('Only key hashes are allow as signers.');
 
+    return this.addSignerKey(credential.hash);
+  }
+
+  /**
+   * Add a public or stake key hash as a required signer of the transaction.
+   */
+  addSignerKey(signer: PaymentKeyHash | StakeKeyHash) {
     this.txBuilder.add_required_signer(
-      C.Ed25519KeyHash.from_bytes(fromHex(credential.hash))
+      C.Ed25519KeyHash.from_bytes(fromHex(signer))
     );
     return this;
   }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -73,8 +73,7 @@ export class Utils {
     throw new Error('No variant matched');
   }
 
-  mintingPolicyToId: (mp: MintingPolicy) => PolicyId = this
-    .validatorToScriptHash;
+  mintingPolicyToId: (mp: MintingPolicy) => PolicyId = this.validatorToScriptHash;
 
   datumToHash(data: Datum): DatumHash {
     return C.hash_plutus_data(C.PlutusData.from_bytes(fromHex(data))).to_hex();

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -508,7 +508,7 @@ export const coreToUtxo = (coreUtxo: Core.TransactionUnspentOutput): UTxO => {
   };
 };
 
-const networkToId = (network: Network): number => {
+export const networkToId = (network: Network): number => {
   if (network === 'Testnet') return 0;
   else if (network === 'Mainnet') return 1;
   throw new Error('Network not found');

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -5,8 +5,12 @@ import {
   AddressDetails,
   Assets,
   Credential,
+  Datum,
+  DatumHash,
   KeyHash,
+  MintingPolicy,
   Network,
+  PolicyId,
   PrivateKey,
   ScriptHash,
   Slot,
@@ -67,6 +71,13 @@ export class Utils {
         .to_hex();
     }
     throw new Error('No variant matched');
+  }
+
+  mintingPolicyToId: (mp: MintingPolicy) => PolicyId = this
+    .validatorToScriptHash;
+
+  datumToHash(data: Datum): DatumHash {
+    return C.hash_plutus_data(C.PlutusData.from_bytes(fromHex(data))).to_hex();
   }
 
   scriptHashToCredential(scriptHash: ScriptHash): Credential {


### PR DESCRIPTION
This PR includes a few general improvements together - do let me know if any of them don't fit the bill for inclusion into the repo.

* Export the `networkToId` function - I've found this useful for extensibility.
* Add 2 utility functions to `lucid.utils`- `mintingPolicyToId` and `datumToHash`.
* Make `payToContract` an alias to `payToAddressWithDatum` - they previously shared the same function body.
* Make `mintAssets` gracefully handle the case where the `redeemer` argument was not provided.
* Add a function to the `Tx` class: `addSignerKey`, this is simply `addSigner` that works directly with the pub/stake key hash.